### PR TITLE
[Do not merge] Fix macOS builds

### DIFF
--- a/lokinetRpcCall.ts
+++ b/lokinetRpcCall.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { ipcMain } from 'electron';
-import * as _zmq from 'zeromq/';
-import * as zmq from 'zeromq/v5-compat';
+import * as _zmq from 'zeromq';
 
 _zmq.context.blocky = false;
 

--- a/webpack.electron.config.js
+++ b/webpack.electron.config.js
@@ -9,6 +9,9 @@ module.exports = {
   devtool: 'source-map',
   entry: './main.ts',
   target: 'electron-main',
+  externals: {
+    "zeromq": "require('zeromq')",
+  },
   module: {
     rules: [
       {


### PR DESCRIPTION
Fixes the following issue

```
Uncaught Exception:
Error: No native build was found for platform=darwin arch=x64 runtime=electron abi=106 uv=1 libc=glibc node=16.14.2 electron=19.0.3 webpack=true
loaded from: /Applications/Lokinet-GUI.app/Contents/Resources/app.asar

at load.path (/Applications/Lokinet-GUI.app/Contents/Resources/app.asar/dist/main.js:12160:9)
at load (/Applications/Lokinet-GUI.app/Contents/Resources/app.asar/dist/main.js:12122:30)
at 2138 (/Applications/Lokinet-GUI.app/Contents/Resources/app.asar/dist/main.js:15852:43)
at webpack_require (/Applications/Lokinet-GUI.app/Contents/Resources/app.asar/dist/main.js:15964:42)
at 141 (/Applications/Lokinet-GUI.app/Contents/Resources/app.asar/dist/main.js:15239:16)
at webpack_require (/Applications/Lokinet-GUI.app/Contents/Resources/app.asar/dist/main.js:15964:42)
at 4594 (/Applications/Lokinet-GUI.app/Contents/Resources/app.asar/dist/main.js:736:11)
at webpack_require (/Applications/Lokinet-GUI.app/Contents/Resources/app.asar/dist/main.js:15964:42)
at /Applications/Lokinet-GUI.app/Contents/Resources/app.asar/dist/main.js:16031:37
at Object.<anonymous> (/Applications/Lokinet-GUI.app/Contents/Resources/app.asar/dist/main.js:16033:12)
```

Not entirely sure if this works since it needs to be tested alongside the lokinet startup code but it does build. If this doen't work then I suggest exploring how we linkup the zeromq binaries into our webpack bundle.

## What this does

Essentially zeromq isn't picked up nicely by webpack when it's creating the output bundle so we import at the electron runtime instead.

See for reference
https://github.com/quepas/electron-leveldown-pouchdb-webpack
https://webpack.js.org/configuration/externals/

**This also drops the unused v5 zeromq compatibility import**

